### PR TITLE
Update app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -449,10 +449,10 @@ const app = Vue.createApp({
 
             
 
-            current_hamming_distance_eq1 = hamming_distance_AV + hamming_distance_PR + hamming_distance_UI
-            current_hamming_distance_eq2 = hamming_distance_AC + hamming_distance_AT
-            current_hamming_distance_eq3eq6 = hamming_distance_VC + hamming_distance_VI + hamming_distance_VA + hamming_distance_CR + hamming_distance_IR + hamming_distance_AR
-            current_hamming_distance_eq4 = hamming_distance_SC + hamming_distance_SI + hamming_distance_SA
+            current_hamming_distance_eq1 = (hamming_distance_AV + hamming_distance_PR + hamming_distance_UI).toFixed(4)
+            current_hamming_distance_eq2 = (hamming_distance_AC + hamming_distance_AT).toFixed(4)
+            current_hamming_distance_eq3eq6 = (hamming_distance_VC + hamming_distance_VI + hamming_distance_VA + hamming_distance_CR + hamming_distance_IR + hamming_distance_AR).toFixed(4)
+            current_hamming_distance_eq4 = (hamming_distance_SC + hamming_distance_SI + hamming_distance_SA).toFixed(4)
             current_hamming_distance_eq5 = 0
 
 
@@ -483,10 +483,10 @@ const app = Vue.createApp({
             normalized_hamming_eq5 = 0
 
             //multiply by step because distance is pure
-            maxHamming_eq1 = this.maxHammingData['eq1'][String(eq1_val)]*step
-            maxHamming_eq2 = this.maxHammingData['eq2'][String(eq2_val)]*step
-            maxHamming_eq3eq6 = this.maxHammingData['eq3'][String(eq3_val)][String(eq6_val)]*step
-            maxHamming_eq4 = this.maxHammingData['eq4'][String(eq4_val)]*step
+            maxHamming_eq1 = (this.maxHammingData['eq1'][String(eq1_val)]-1)*step
+            maxHamming_eq2 = (this.maxHammingData['eq2'][String(eq2_val)]-1)*step
+            maxHamming_eq3eq6 = (this.maxHammingData['eq3'][String(eq3_val)][String(eq6_val)]-1)*step
+            maxHamming_eq4 = (this.maxHammingData['eq4'][String(eq4_val)]-1)*step
 
             if (!isNaN(available_distance_eq1)){
                 n_existing_lower=n_existing_lower+1


### PR DESCRIPTION
The maxHamming_eq* must be decreased by one (or, equivalently, weights must be changed in the max_hamming.js), otherwise the percent_to_next_eq*_hamming is always < 1.

Example: CVSS:4.0/AV:L/AC:H/AT:P/PR:N/UI:A/VC:N/VI:L/VA:N/SC:H/SI:N/SA:N

percent_to_next_eq1_hamming is 3/4 (it should be 1) percent to_next_eq4_hamming is 4/5 (it should be 1)

This results in a significantly "off" CVSS-B score: 4.0 (it should be 3.5)

I have also used toFixed(4) to round conservatively (i.e. 0.300001 rounded to 0.3, and 0.59999 rounded to 0.6) => feel free to ignore this change