### PR TITLE
Typos in the latest CVSS4 specs

### DIFF
--- a/cvss_config.js
+++ b/cvss_config.js
@@ -561,7 +561,7 @@ cvssConfig = {
               "tooltip": "",
               "value": "L"
             },
-            "Negligible (N)": {
+            "None (N)": {
               "tooltip": "",
               "value": "N"
             },
@@ -588,7 +588,7 @@ cvssConfig = {
               "tooltip": "",
               "value": "L"
             },
-            "Negligible (N)": {
+            "None (N)": {
               "tooltip": "",
               "value": "N"
             }
@@ -615,7 +615,7 @@ cvssConfig = {
               "tooltip": "",
               "value": "L"
             },
-            "Negligible (N)": {
+            "None (N)": {
               "tooltip": "",
               "value": "N"
             }


### PR DESCRIPTION
The last release of the CVSS4 spec makes this clear, so I am closing this pull request.

> Note: For MSC (Modified Subsequent System Confidentiality), MSI (Modified Subsequent System Integrity), and MSA (Modified Subsequent System Availability), the lowest metric value is “Negligible” (N), not “None” (N).

However, the spec has a typo where the word "Negligible" is being used instead of "None". The typo is in [Table 7 - Metric Value](https://www.first.org/cvss/v4.0/specification-document#Table-7-Confidentiality-Impact-to-the-Subsequent-System-SC).

And another typo in **Table 15: Modified Base Metrics**:

> There is also a highest severity level, Safety (S), in addition to the same values as the corresponding Base Metric (High, **Medium**??, Low). The value Not Defined (X) is the default value.

There is no medium severity level for confidentiality, integrity or availability.